### PR TITLE
specv8 fix

### DIFF
--- a/combine_global_csv.py
+++ b/combine_global_csv.py
@@ -36,7 +36,7 @@ if __name__ == '__main__':
                             writer.writeheader()
     
                         global_data_dict = next(global_csv_file_reader)
-                        workload_name = name if len(sim_file_names) == 1 else '{}.{}'.format(name, sim_file_name.split('.')[0])
+                        workload_name = name if len(sim_file_names) == 1 else '{}.{}'.format(name, sim_file_name.rsplit('.', 1)[0])
                         extra_data_dict = {'name': workload_name}
                         if workload_class:
                             extra_data_dict |= {'class': workload_class}

--- a/cpuv8_collector.py
+++ b/cpuv8_collector.py
@@ -67,7 +67,7 @@ workload,class
 881.neutron_s,fp_speed 
 '''
 
-reader = csv.DictReader(workload_class.split('\n'))
+reader = csv.DictReader([line.rstrip() for line in workload_class.split('\n')])
 workloads_classes = {}
 for line in reader:
     workloads_classes[line['workload']] = line['class']


### PR DESCRIPTION
1. For final global csv,  Benchmark name should be using the file name without suffix.
This is needed to distinguish specv8 benchmarks with different inputs. I am not sure how spec17 works without it.

2. Small fix on Kazi's script so benchmarks are correctly categorized. 